### PR TITLE
Refine frontend reload toast action

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -143,10 +143,21 @@ export default function App() {
               </span>
             </div>
 
-            <button className="secondary-button toast-action-button" onClick={update.requestReloadToUpdate} type="button">
-              <IconReload />
-              <span>Reload</span>
-            </button>
+            <ActionTooltip
+              align="right"
+              side="above"
+              wrapperClassName="reload-toast-action"
+              content={<span className="action-tooltip-label">Reload</span>}
+            >
+              <button
+                aria-label="Reload"
+                className="secondary-button icon-only-button reload-toast-button"
+                onClick={update.requestReloadToUpdate}
+                type="button"
+              >
+                <IconReload />
+              </button>
+            </ActionTooltip>
           </div>
         ) : null}
 

--- a/apps/frontend/src/features/chat/test/registerUpdateSuite.tsx
+++ b/apps/frontend/src/features/chat/test/registerUpdateSuite.tsx
@@ -60,6 +60,7 @@ export function registerUpdateSuite(context: AppTestContext) {
     context.mockFrontendVersion("new-frontend-version");
 
     const reloadSpy = vi.spyOn(browser, "reloadWindow").mockImplementation(() => undefined);
+    const user = userEvent.setup();
 
     try {
       context.renderApp();
@@ -68,7 +69,11 @@ export function registerUpdateSuite(context: AppTestContext) {
       expect(await screen.findByText("A newer version is available.")).toBeInTheDocument();
       expect(screen.getByText("Reload when you're ready to use the latest version.")).toBeInTheDocument();
 
-      await userEvent.click(screen.getByRole("button", { name: "Reload" }));
+      const reloadButton = screen.getByRole("button", { name: "Reload" });
+      await user.hover(reloadButton);
+      expect(screen.getByRole("tooltip")).toHaveTextContent("Reload");
+
+      await user.click(reloadButton);
 
       expect(screen.queryByRole("alertdialog", { name: "Reload to update?" })).not.toBeInTheDocument();
       expect(reloadSpy).toHaveBeenCalledTimes(1);

--- a/apps/frontend/src/styles/layout.css
+++ b/apps/frontend/src/styles/layout.css
@@ -133,6 +133,7 @@
   width: 1.25rem;
   height: 1.25rem;
   flex: 0 0 auto;
+  display: block;
   fill: none;
   stroke: currentColor;
   stroke-width: 1.9;
@@ -317,12 +318,24 @@
   color: var(--muted);
 }
 
-.toast-action-button {
+.reload-toast-action {
   flex: 0 0 auto;
   margin-left: auto;
-  padding: 10px 16px;
+}
+
+.reload-toast-button {
+  width: 42px;
+  min-width: 42px;
+  height: 42px;
+  padding: 0;
   background: rgba(182, 71, 30, 0.1);
   color: var(--accent);
+}
+
+.reload-toast-button .button-icon {
+  width: 1.08rem;
+  height: 1.08rem;
+  stroke-width: 1.75;
 }
 
 @keyframes button-spinner-rotate {

--- a/apps/frontend/src/styles/responsive.css
+++ b/apps/frontend/src/styles/responsive.css
@@ -67,10 +67,9 @@
     text-align: center;
   }
 
-  .toast-action-button {
-    width: 100%;
-    justify-content: center;
+  .reload-toast-action {
     margin-left: 0;
+    align-self: center;
   }
 }
 


### PR DESCRIPTION
## Summary
- replace the reload toast text button with the shared icon-only button pattern and tooltip
- tune the toast action sizing so the reload icon no longer feels clipped
- cover the tooltip behavior in the existing frontend update test suite

## Verification
- npm test -- --run src/App.test.tsx
- npm run build