### PR TITLE
Make new menu trigger icon-only

### DIFF
--- a/apps/frontend/src/features/chat/components/NewMenu.test.tsx
+++ b/apps/frontend/src/features/chat/components/NewMenu.test.tsx
@@ -21,6 +21,7 @@ describe("NewMenu", () => {
     const trigger = screen.getByRole("button", { name: "New" });
     expect(trigger).toHaveAttribute("aria-haspopup", "menu");
     expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(trigger).not.toHaveTextContent("New");
   });
 
   it("opens the menu and focuses the first item on click", async () => {

--- a/apps/frontend/src/features/chat/components/NewMenu.tsx
+++ b/apps/frontend/src/features/chat/components/NewMenu.tsx
@@ -173,15 +173,15 @@ export function NewMenu({
       <button
         ref={triggerRef}
         aria-controls={menuId}
+        aria-label="New"
         aria-expanded={isOpen}
         aria-haspopup="menu"
-        className="secondary-button new-menu-trigger"
+        className="secondary-button icon-only-button new-menu-trigger"
         type="button"
         onClick={handleTriggerClick}
         onKeyDown={handleTriggerKeyDown}
       >
         <IconNewChat />
-        <span className="new-menu-trigger-label">New</span>
       </button>
 
       <div

--- a/apps/frontend/src/styles/layout.css
+++ b/apps/frontend/src/styles/layout.css
@@ -185,16 +185,7 @@
 .new-menu-trigger {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 0 14px;
-  width: auto;
-  min-width: 42px;
-}
-
-.new-menu-trigger-label {
-  font-size: 0.85rem;
-  font-weight: 500;
-  letter-spacing: 0.01em;
+  justify-content: center;
 }
 
 .new-menu-panel {


### PR DESCRIPTION
## Summary
- remove the visible `New` text from the new-menu trigger
- keep the trigger accessible with an explicit `aria-label`
- align the trigger styling with the existing icon-only controls

## Verification
- `npm test -- NewMenu`
- `npm run build`