### PR TITLE
Handle Azure Foundry FLUX data responses

### DIFF
--- a/apps/backend/internal/azurefoundry/client.go
+++ b/apps/backend/internal/azurefoundry/client.go
@@ -178,6 +178,15 @@ type syncResponse struct {
 	Prompt string      `json:"prompt,omitempty"`
 }
 
+type openAIImage struct {
+	B64JSON string `json:"b64_json"`
+	URL     string `json:"url"`
+}
+
+type openAIResponse struct {
+	Data []openAIImage `json:"data"`
+}
+
 // asyncResponse is the response body for a 202 Accepted (async job queued).
 type asyncResponse struct {
 	ID          string   `json:"id"`
@@ -414,16 +423,42 @@ func (c *Client) normalizeSyncResponse(rawBody []byte) (imageprovider.GenerateRe
 		return imageprovider.GenerateResult{}, fmt.Errorf("decode sync response: %w", err)
 	}
 
-	images := make([]imageprovider.OutputImage, 0, len(sr.Images))
-	for _, img := range sr.Images {
-		out, err := decodeImageField(img.URL)
-		if err != nil {
-			return imageprovider.GenerateResult{}, fmt.Errorf("normalize image: %w", err)
+	if len(sr.Images) > 0 {
+		images := make([]imageprovider.OutputImage, 0, len(sr.Images))
+		for _, img := range sr.Images {
+			out, err := decodeImageField(img.URL)
+			if err != nil {
+				return imageprovider.GenerateResult{}, fmt.Errorf("normalize image: %w", err)
+			}
+			if out.MediaType == "" && img.ContentType != "" {
+				out.MediaType = img.ContentType
+			}
+			images = append(images, out)
 		}
-		if out.MediaType == "" && img.ContentType != "" {
-			out.MediaType = img.ContentType
+		return imageprovider.GenerateResult{Images: images}, nil
+	}
+
+	var or openAIResponse
+	if err := json.Unmarshal(rawBody, &or); err != nil {
+		return imageprovider.GenerateResult{}, fmt.Errorf("decode alternate sync response: %w", err)
+	}
+
+	images := make([]imageprovider.OutputImage, 0, len(or.Data))
+	for _, img := range or.Data {
+		switch {
+		case strings.TrimSpace(img.B64JSON) != "":
+			decoded, err := base64.StdEncoding.DecodeString(img.B64JSON)
+			if err != nil {
+				return imageprovider.GenerateResult{}, fmt.Errorf("decode b64_json image data: %w", err)
+			}
+			images = append(images, imageprovider.OutputImage{Data: decoded})
+		case strings.TrimSpace(img.URL) != "":
+			out, err := decodeImageField(img.URL)
+			if err != nil {
+				return imageprovider.GenerateResult{}, fmt.Errorf("normalize data image: %w", err)
+			}
+			images = append(images, out)
 		}
-		images = append(images, out)
 	}
 
 	return imageprovider.GenerateResult{Images: images}, nil

--- a/apps/backend/internal/azurefoundry/client_test.go
+++ b/apps/backend/internal/azurefoundry/client_test.go
@@ -485,6 +485,81 @@ func TestGenerateNormalizesImmediateURLResponse(t *testing.T) {
 	}
 }
 
+func TestGenerateNormalizesOpenAIStyleBase64Response(t *testing.T) {
+	t.Parallel()
+
+	imgData := []byte("raw-png-bytes")
+	encoded := base64.StdEncoding.EncodeToString(imgData)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(openAIResponse{
+			Data: []openAIImage{{B64JSON: encoded}},
+		})
+	}))
+	defer srv.Close()
+
+	c, _ := NewClient(srv.URL, "key", ClientOptions{HTTPClient: srv.Client()})
+
+	result, err := c.Generate(context.Background(), imageprovider.GenerateRequest{
+		Mode:   imageprovider.ModeTextToImage,
+		Prompt: "test",
+	})
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	if !result.Completed() {
+		t.Fatal("result.Completed() = false, want true")
+	}
+	if len(result.Images) != 1 {
+		t.Fatalf("len(result.Images) = %d, want 1", len(result.Images))
+	}
+	img := result.Images[0]
+	if string(img.Data) != string(imgData) {
+		t.Errorf("img.Data = %q, want %q", img.Data, imgData)
+	}
+	if img.URL != "" {
+		t.Errorf("img.URL = %q, want empty", img.URL)
+	}
+}
+
+func TestGenerateNormalizesOpenAIStyleURLResponse(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(openAIResponse{
+			Data: []openAIImage{{URL: "https://cdn.example.com/out.png"}},
+		})
+	}))
+	defer srv.Close()
+
+	c, _ := NewClient(srv.URL, "key", ClientOptions{HTTPClient: srv.Client()})
+
+	result, err := c.Generate(context.Background(), imageprovider.GenerateRequest{
+		Mode:   imageprovider.ModeTextToImage,
+		Prompt: "test",
+	})
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	if !result.Completed() {
+		t.Fatal("result.Completed() = false, want true")
+	}
+	if len(result.Images) != 1 {
+		t.Fatalf("len(result.Images) = %d, want 1", len(result.Images))
+	}
+	img := result.Images[0]
+	if img.URL != "https://cdn.example.com/out.png" {
+		t.Errorf("img.URL = %q", img.URL)
+	}
+	if img.Data != nil {
+		t.Errorf("img.Data should be nil for URL response")
+	}
+}
+
 func TestGenerateNormalizesAsyncJobResponse(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- accept Azure Foundry FLUX sync responses returned in OpenAI-style `data[]` format
- continue supporting the existing `images[]` response format
- add regression tests for inline base64 and URL-based `data[]` payloads

## Verification
- `GOCACHE=/tmp/ulduar-go-build go test ./internal/azurefoundry`
