### PR TITLE
Refine image composer reference flow

### DIFF
--- a/apps/frontend/src/features/chat/components/NewMenu.test.tsx
+++ b/apps/frontend/src/features/chat/components/NewMenu.test.tsx
@@ -28,15 +28,15 @@ describe("NewMenu", () => {
     renderNewMenu();
     await userEvent.click(screen.getByRole("button", { name: "New" }));
     expect(screen.getByRole("button", { name: "New" })).toHaveAttribute("aria-expanded", "true");
-    expect(screen.getByRole("menuitem", { name: "New chat" })).toHaveFocus();
+    expect(screen.getByRole("menuitem", { name: "New Chat" })).toHaveFocus();
   });
 
-  it("calls onNewChat and closes menu when New chat item is clicked, returning focus to trigger", async () => {
+  it("calls onNewChat and closes menu when New Chat item is clicked, returning focus to trigger", async () => {
     const onNewChat = vi.fn();
     renderNewMenu({ onNewChat });
 
     await userEvent.click(screen.getByRole("button", { name: "New" }));
-    await userEvent.click(screen.getByRole("menuitem", { name: "New chat" }));
+    await userEvent.click(screen.getByRole("menuitem", { name: "New Chat" }));
 
     const trigger = screen.getByRole("button", { name: "New" });
     expect(onNewChat).toHaveBeenCalledTimes(1);
@@ -69,7 +69,7 @@ describe("NewMenu", () => {
     renderNewMenu();
     const trigger = screen.getByRole("button", { name: "New" });
     await userEvent.click(trigger);
-    expect(screen.getByRole("menuitem", { name: "New chat" })).toHaveFocus();
+    expect(screen.getByRole("menuitem", { name: "New Chat" })).toHaveFocus();
 
     // Simulate an outside pointerdown on a non-focusable element (e.g. body).
     fireEvent.pointerDown(document.body);
@@ -133,10 +133,10 @@ describe("NewMenu", () => {
 
     await userEvent.click(screen.getByRole("button", { name: "New" }));
 
-    const newChatItem = screen.getByRole("menuitem", { name: "New chat" });
-    const newImageItem = screen.getByRole("menuitem", { name: "New image" });
+    const newChatItem = screen.getByRole("menuitem", { name: "New Chat" });
+    const newImageItem = screen.getByRole("menuitem", { name: "New Image" });
 
-    // New chat is the focused (active) item; New image is disabled — always tabIndex=-1.
+    // New Chat is the focused (active) item; New Image is disabled — always tabIndex=-1.
     expect(newChatItem).toHaveAttribute("tabindex", "0");
     expect(newImageItem).toHaveAttribute("tabindex", "-1");
   });
@@ -154,41 +154,41 @@ describe("NewMenu", () => {
     expect(items[0]).toHaveFocus();
   });
 
-  it("does not render New image item when isImageGenerationEnabled is false", async () => {
+  it("does not render New Image item when isImageGenerationEnabled is false", async () => {
     renderNewMenu({ isImageGenerationEnabled: false });
     await userEvent.click(screen.getByRole("button", { name: "New" }));
-    expect(screen.queryByRole("menuitem", { name: "New image" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "New Image" })).not.toBeInTheDocument();
   });
 
-  it("renders New image item as enabled when isImageGenerationEnabled and isImageGenerationAvailable are true", async () => {
+  it("renders New Image item as enabled when isImageGenerationEnabled and isImageGenerationAvailable are true", async () => {
     const onNewImage = vi.fn();
     renderNewMenu({ isImageGenerationEnabled: true, isImageGenerationAvailable: true, onNewImage });
 
     await userEvent.click(screen.getByRole("button", { name: "New" }));
-    const item = screen.getByRole("menuitem", { name: "New image" });
+    const item = screen.getByRole("menuitem", { name: "New Image" });
     expect(item).not.toHaveAttribute("aria-disabled");
 
     await userEvent.click(item);
     expect(onNewImage).toHaveBeenCalledTimes(1);
   });
 
-  it("renders New image item as disabled when isImageGenerationEnabled is true but isImageGenerationAvailable is false", async () => {
+  it("renders New Image item as disabled when isImageGenerationEnabled is true but isImageGenerationAvailable is false", async () => {
     const onNewImage = vi.fn();
     renderNewMenu({ isImageGenerationEnabled: true, isImageGenerationAvailable: false, onNewImage });
 
     await userEvent.click(screen.getByRole("button", { name: "New" }));
-    const item = screen.getByRole("menuitem", { name: "New image" });
+    const item = screen.getByRole("menuitem", { name: "New Image" });
     expect(item).toHaveAttribute("aria-disabled", "true");
 
     await userEvent.click(item);
     expect(onNewImage).not.toHaveBeenCalled();
   });
 
-  it("renders New image item as disabled when the handler is missing", async () => {
+  it("renders New Image item as disabled when the handler is missing", async () => {
     renderNewMenu({ isImageGenerationEnabled: true, isImageGenerationAvailable: true, onNewImage: undefined });
 
     await userEvent.click(screen.getByRole("button", { name: "New" }));
-    const item = screen.getByRole("menuitem", { name: "New image" });
+    const item = screen.getByRole("menuitem", { name: "New Image" });
     expect(item).toHaveAttribute("aria-disabled", "true");
     expect(item).toHaveAttribute("tabindex", "-1");
   });
@@ -197,10 +197,10 @@ describe("NewMenu", () => {
     renderNewMenu({ isImageGenerationEnabled: true, isImageGenerationAvailable: false });
 
     await userEvent.click(screen.getByRole("button", { name: "New" }));
-    const newChatItem = screen.getByRole("menuitem", { name: "New chat" });
+    const newChatItem = screen.getByRole("menuitem", { name: "New Chat" });
     expect(newChatItem).toHaveFocus();
 
-    // ArrowDown should wrap because the only enabled item is New chat
+    // ArrowDown should wrap because the only enabled item is New Chat
     await userEvent.keyboard("{ArrowDown}");
     expect(newChatItem).toHaveFocus();
   });

--- a/apps/frontend/src/features/chat/components/NewMenu.tsx
+++ b/apps/frontend/src/features/chat/components/NewMenu.tsx
@@ -206,7 +206,7 @@ export function NewMenu({
             close();
           }}
         >
-          New chat
+          New Chat
         </button>
 
         {isImageGenerationEnabled && (
@@ -224,7 +224,7 @@ export function NewMenu({
               close();
             }}
           >
-            New image
+            New Image
           </button>
         )}
       </div>

--- a/apps/frontend/src/features/chat/test/registerNewMenuSuite.tsx
+++ b/apps/frontend/src/features/chat/test/registerNewMenuSuite.tsx
@@ -16,10 +16,10 @@ export function registerNewMenuSuite(context: AppTestContext) {
     expect(trigger).toHaveAttribute("aria-expanded", "false");
 
     // Menu is closed: items are hidden from the accessibility tree via aria-hidden
-    expect(screen.queryByRole("menuitem", { name: "New chat" })).toBeNull();
+    expect(screen.queryByRole("menuitem", { name: "New Chat" })).toBeNull();
   });
 
-  it("opens the menu and shows New chat item", async () => {
+  it("opens the menu and shows New Chat item", async () => {
     context.renderApp();
     await context.waitForReady();
 
@@ -27,7 +27,7 @@ export function registerNewMenuSuite(context: AppTestContext) {
     await userEvent.click(trigger);
 
     expect(trigger).toHaveAttribute("aria-expanded", "true");
-    expect(screen.getByRole("menuitem", { name: "New chat" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "New Chat" })).toBeInTheDocument();
   });
 
   it("closes the menu on second trigger click", async () => {
@@ -40,7 +40,7 @@ export function registerNewMenuSuite(context: AppTestContext) {
 
     await userEvent.click(trigger);
     expect(trigger).toHaveAttribute("aria-expanded", "false");
-    expect(screen.queryByRole("menuitem", { name: "New chat" })).toBeNull();
+    expect(screen.queryByRole("menuitem", { name: "New Chat" })).toBeNull();
   });
 
   it("closes the menu on Escape and restores focus to the trigger", async () => {
@@ -68,14 +68,14 @@ export function registerNewMenuSuite(context: AppTestContext) {
     expect(trigger).toHaveAttribute("aria-expanded", "false");
   });
 
-  it("starts a new chat when New chat is selected and closes the menu", async () => {
+  it("starts a new chat when New Chat is selected and closes the menu", async () => {
     context.renderApp();
     await context.waitForReady();
 
     const initialCallCount = context.mockedCreateSession.mock.calls.length;
 
     await userEvent.click(screen.getByRole("button", { name: "New" }));
-    await userEvent.click(screen.getByRole("menuitem", { name: "New chat" }));
+    await userEvent.click(screen.getByRole("menuitem", { name: "New Chat" }));
 
     expect(screen.getByRole("button", { name: "New" })).toHaveAttribute("aria-expanded", "false");
     expect(context.mockedCreateSession.mock.calls.length).toBeGreaterThan(initialCallCount);
@@ -89,16 +89,16 @@ export function registerNewMenuSuite(context: AppTestContext) {
     trigger.focus();
     await userEvent.keyboard("{Enter}");
 
-    expect(screen.getByRole("menuitem", { name: "New chat" })).toHaveFocus();
+    expect(screen.getByRole("menuitem", { name: "New Chat" })).toHaveFocus();
   });
 
-  it("shows New image item only when image generation is enabled in the test environment", async () => {
+  it("shows New Image item only when image generation is enabled in the test environment", async () => {
     context.renderApp();
     await context.waitForReady();
 
     await userEvent.click(screen.getByRole("button", { name: "New" }));
 
-    const newImageItem = screen.queryByRole("menuitem", { name: "New image" });
+    const newImageItem = screen.queryByRole("menuitem", { name: "New Image" });
 
     if (isImageGenerationEnabled) {
       expect(newImageItem).toBeInTheDocument();

--- a/apps/frontend/src/features/chat/test/registerRenderingSuite.tsx
+++ b/apps/frontend/src/features/chat/test/registerRenderingSuite.tsx
@@ -358,7 +358,7 @@ export function registerRenderingSuite(context: AppTestContext) {
     });
 
     await userEvent.click(screen.getByRole("button", { name: "New" }));
-    await userEvent.click(screen.getByRole("menuitem", { name: "New chat" }));
+    await userEvent.click(screen.getByRole("menuitem", { name: "New Chat" }));
     await screen.findByText("Ready for the next turn.");
 
     await userEvent.type(screen.getByLabelText("Message"), "Second run");

--- a/apps/frontend/src/features/imagegen/components/ImageComposer.tsx
+++ b/apps/frontend/src/features/imagegen/components/ImageComposer.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useRef, useState, type ChangeEvent, type KeyboardEvent, type MouseEventHandler, type RefObject, type SubmitEvent } from "react";
+import { useEffect, useRef, useState, type ChangeEvent, type KeyboardEvent, type RefObject, type SubmitEvent } from "react";
 
-import type { ImageGenerationCapabilitiesResponse } from "../../../lib/api";
+import type { ImageGenerationCapabilitiesResponse, ImageGenerationMode } from "../../../lib/api";
 import { ActionTooltip } from "../../chat/components/ActionTooltip";
-import { IconAttachment, IconClose, IconSend, IconSpinner } from "../../chat/components/icons";
-import { imagePromptPlaceholder, referenceImageInputAccept } from "../constants";
+import { IconClose, IconSend, IconSpinner } from "../../chat/components/icons";
+import { referenceImageInputAccept } from "../constants";
 import type { ImageSubmissionState, ReusableImageSource, SelectedReferenceImage } from "../types";
 import { ImageReusePicker } from "./ImageReusePicker";
 
@@ -22,6 +22,7 @@ type ImageComposerProps = {
   onResolutionChange: (event: ChangeEvent<HTMLSelectElement>) => void;
   onReuseImage: (source: ReusableImageSource) => Promise<void>;
   onSubmit: (event: SubmitEvent<HTMLFormElement>) => Promise<void>;
+  mode: ImageGenerationMode;
   prompt: string;
   referenceImages: SelectedReferenceImage[];
   reusableImages: ReusableImageSource[];
@@ -47,6 +48,7 @@ export function ImageComposer({
   onResolutionChange,
   onReuseImage,
   onSubmit,
+  mode,
   prompt,
   referenceImages,
   reusableImages,
@@ -58,6 +60,11 @@ export function ImageComposer({
 }: ImageComposerProps) {
   const previewUrlMapRef = useRef<Map<string, string>>(new Map());
   const [previewUrls, setPreviewUrls] = useState<Map<string, string>>(new Map());
+  const isEditMode = mode === "image_edit";
+  const modeLabel = isEditMode ? "Edit" : "Generate";
+  const inputPlaceholder = isEditMode
+    ? "Describe the result you want. Add reference images from file or this session to guide the next image. Shift + Enter to generate."
+    : "Describe the result you want. Add reference images from file or this session when you want the next image to follow or edit them. Shift + Enter to generate.";
 
   // Incrementally update blob URLs for reference image thumbnails.
   useEffect(() => {
@@ -91,13 +98,10 @@ export function ImageComposer({
     };
   }, []);
 
-  const handleAttachClick: MouseEventHandler<HTMLButtonElement> = () => {
-    onOpenFilePicker();
-  };
-
   return (
     <form className="composer image-composer" onSubmit={onSubmit}>
       <div className="composer-input-shell composer-input-shell-inline">
+        <span className="image-composer-mode-badge">{modeLabel}</span>
         <textarea
           ref={composerRef}
           className="composer-input"
@@ -105,7 +109,7 @@ export function ImageComposer({
           value={prompt}
           onChange={onPromptChange}
           onKeyDown={onPromptKeyDown}
-          placeholder={imagePromptPlaceholder}
+          placeholder={inputPlaceholder}
           rows={5}
           disabled={busy}
         />
@@ -132,22 +136,13 @@ export function ImageComposer({
         </div>
 
         <div className="composer-footer-start">
-          <ActionTooltip
-            side="above"
-            dismissOnPress
-            openOnFocus={false}
-            content={<span className="action-tooltip-label">Add reference images</span>}
-          >
-            <button
-              aria-label="Add reference images"
-              className="attachment-button icon-only-button"
-              disabled={busy}
-              onClick={handleAttachClick}
-              type="button"
-            >
-              <IconAttachment />
-            </button>
-          </ActionTooltip>
+          <ImageReusePicker
+            busy={busy}
+            onOpenFilePicker={onOpenFilePicker}
+            onReuseImage={onReuseImage}
+            reusingImageIds={reusingImageIds}
+            reusableImages={reusableImages}
+          />
 
           <div className="composer-attachment-list">
             {referenceImages.map(({ id, file }) => {
@@ -208,13 +203,6 @@ export function ImageComposer({
           </ActionTooltip>
         </div>
       </div>
-
-      <ImageReusePicker
-        busy={busy}
-        onReuseImage={onReuseImage}
-        reusingImageIds={reusingImageIds}
-        reusableImages={reusableImages}
-      />
 
       {screenError ? <p className="screen-error">{screenError}</p> : null}
 

--- a/apps/frontend/src/features/imagegen/components/ImageReusePicker.tsx
+++ b/apps/frontend/src/features/imagegen/components/ImageReusePicker.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState, type KeyboardEvent } from "react";
 
+import { IconAttachment, IconClose } from "../../chat/components/icons";
 import type { ReusableImageSource } from "../types";
 
 type ImageReusePickerProps = {
   busy: boolean;
+  onOpenFilePicker: () => void;
   onReuseImage: (source: ReusableImageSource) => Promise<void>;
   reusingImageIds: string[];
   reusableImages: ReusableImageSource[];
@@ -11,85 +13,218 @@ type ImageReusePickerProps = {
 
 export function ImageReusePicker({
   busy,
+  onOpenFilePicker,
   onReuseImage,
   reusingImageIds,
   reusableImages,
 }: ImageReusePickerProps) {
-  const previewUrlMapRef = useRef<Map<string, string>>(new Map());
-  const [previewUrls, setPreviewUrls] = useState<Map<string, string>>(new Map());
-  const uploadedImages = reusableImages.filter((image) => image.kind === "upload");
-  const generatedImages = reusableImages.filter((image) => image.kind === "generated");
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const fileItemRef = useRef<HTMLButtonElement>(null);
+  const sessionItemRef = useRef<HTMLButtonElement>(null);
+  const menuId = useId();
+  const panelId = useId();
+  const generatedImages = reusableImages;
 
   useEffect(() => {
-    const map = previewUrlMapRef.current;
-    const uploadEntries = reusableImages.filter(
-      (image): image is ReusableImageSource & { file: File } => image.kind === "upload" && !!image.file,
-    );
-    const nextIds = new Set(uploadEntries.map((image) => image.id));
-
-    for (const [id, url] of [...map]) {
-      if (!nextIds.has(id)) {
-        URL.revokeObjectURL(url);
-        map.delete(id);
-      }
+    if (!isOpen && !isMenuOpen) {
+      return;
     }
 
-    for (const image of uploadEntries) {
-      if (!map.has(image.id)) {
-        map.set(image.id, URL.createObjectURL(image.file));
+    function handlePointerDown(event: PointerEvent) {
+      const target = event.target as Node;
+      if (
+        triggerRef.current?.contains(target) ||
+        menuRef.current?.contains(target) ||
+        panelRef.current?.contains(target)
+      ) {
+        return;
       }
+
+      setIsMenuOpen(false);
+      setIsOpen(false);
     }
 
-    setPreviewUrls(new Map(map));
-  }, [reusableImages]);
+    document.addEventListener("pointerdown", handlePointerDown);
+    return () => document.removeEventListener("pointerdown", handlePointerDown);
+  }, [isMenuOpen, isOpen]);
 
   useEffect(() => {
-    const map = previewUrlMapRef.current;
-    return () => {
-      for (const url of map.values()) {
-        URL.revokeObjectURL(url);
-      }
-      map.clear();
-    };
+    if (reusableImages.length === 0) {
+      setIsOpen(false);
+    }
+  }, [reusableImages.length]);
+
+  useEffect(() => {
+    if (!isMenuOpen) {
+      return;
+    }
+
+    fileItemRef.current?.focus();
+  }, [generatedImages.length, isMenuOpen]);
+
+  const closeAll = useCallback(() => {
+    setIsMenuOpen(false);
+    setIsOpen(false);
   }, []);
 
-  if (reusableImages.length === 0) {
-    return null;
+  function openMenu() {
+    setIsOpen(false);
+    setIsMenuOpen(true);
+  }
+
+  function closeMenu() {
+    setIsMenuOpen(false);
+  }
+
+  function handlePanelKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      closeAll();
+      triggerRef.current?.focus();
+    }
+  }
+
+  function handleMenuKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      closeAll();
+      triggerRef.current?.focus();
+      return;
+    }
+
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+
+      if (document.activeElement === fileItemRef.current && generatedImages.length > 0) {
+        sessionItemRef.current?.focus();
+        return;
+      }
+
+      if (document.activeElement === sessionItemRef.current) {
+        fileItemRef.current?.focus();
+        return;
+      }
+
+      fileItemRef.current?.focus();
+    }
   }
 
   return (
-    <section className="image-reuse-panel" aria-label="Reuse images from this session">
-      <div className="image-reuse-header">
-        <p className="image-reuse-title">Reuse from this session</p>
-        <span className="image-reuse-description">
-          Select earlier uploads or generated outputs to attach them to this draft.
-        </span>
+    <div className="image-reuse-anchor">
+      <button
+        ref={triggerRef}
+        aria-controls={isOpen ? panelId : menuId}
+        aria-expanded={isMenuOpen || isOpen}
+        aria-haspopup={isOpen ? "dialog" : "menu"}
+        aria-label="Add reference images"
+        className="attachment-button icon-only-button"
+        disabled={busy}
+        type="button"
+        onClick={() => {
+          if (isOpen || isMenuOpen) {
+            closeAll();
+            return;
+          }
+
+          openMenu();
+        }}
+      >
+        <IconAttachment />
+      </button>
+
+      <div
+        ref={menuRef}
+        id={menuId}
+        role="menu"
+        aria-label="Reference image sources"
+        aria-hidden={!isMenuOpen}
+        className="image-reference-menu"
+        data-open={isMenuOpen ? "true" : "false"}
+        onKeyDown={handleMenuKeyDown}
+      >
+        <button
+          ref={fileItemRef}
+          role="menuitem"
+          type="button"
+          className="image-reference-menu-item"
+          onClick={() => {
+            closeMenu();
+            onOpenFilePicker();
+            triggerRef.current?.focus();
+          }}
+        >
+          From File
+        </button>
+
+        <button
+          ref={sessionItemRef}
+          role="menuitem"
+          type="button"
+          className="image-reference-menu-item"
+          disabled={generatedImages.length === 0}
+          aria-disabled={generatedImages.length === 0 ? "true" : undefined}
+          onClick={() => {
+            if (generatedImages.length === 0) {
+              return;
+            }
+
+            setIsMenuOpen(false);
+            setIsOpen(true);
+          }}
+        >
+          From Session
+        </button>
       </div>
 
-      {uploadedImages.length > 0 ? (
-        <ImageReuseGroup
-          busy={busy}
-          buttonLabelPrefix="Attach previous upload"
-          onReuseImage={onReuseImage}
-          previewUrls={previewUrls}
-          reusingImageIds={reusingImageIds}
-          sources={uploadedImages}
-          title="Previous uploads"
-        />
-      ) : null}
+      <div
+        ref={panelRef}
+        id={panelId}
+        role="dialog"
+        aria-label="Reference images from this session"
+        aria-hidden={!isOpen}
+        className="image-reuse-panel"
+        data-open={isOpen ? "true" : "false"}
+        onKeyDown={handlePanelKeyDown}
+      >
+        <div className="image-reuse-header">
+          <div className="image-reuse-header-copy">
+            <p className="image-reuse-title">From session</p>
+            <span className="image-reuse-description">
+              Select a generated image from this session to attach it as a reference for the next result.
+            </span>
+          </div>
 
-      {generatedImages.length > 0 ? (
-        <ImageReuseGroup
-          busy={busy}
-          buttonLabelPrefix="Attach generated image"
-          onReuseImage={onReuseImage}
-          previewUrls={previewUrls}
-          reusingImageIds={reusingImageIds}
-          sources={generatedImages}
-          title="Generated outputs"
-        />
-      ) : null}
-    </section>
+          <button
+            aria-label="Close session image picker"
+            className="image-reuse-close"
+            type="button"
+            onClick={() => {
+              setIsOpen(false);
+              triggerRef.current?.focus();
+            }}
+          >
+            <IconClose />
+          </button>
+        </div>
+
+        {generatedImages.length > 0 ? (
+          <ImageReuseGroup
+            busy={busy}
+            buttonLabelPrefix="Attach generated image"
+            onReuseImage={onReuseImage}
+            reusingImageIds={reusingImageIds}
+            sources={generatedImages}
+            title="Generated images"
+          />
+        ) : (
+          <p className="image-reuse-empty">No generated images in this session yet.</p>
+        )}
+      </div>
+    </div>
   );
 }
 
@@ -97,7 +232,6 @@ type ImageReuseGroupProps = {
   busy: boolean;
   buttonLabelPrefix: string;
   onReuseImage: (source: ReusableImageSource) => Promise<void>;
-  previewUrls: Map<string, string>;
   reusingImageIds: string[];
   sources: ReusableImageSource[];
   title: string;
@@ -107,7 +241,6 @@ function ImageReuseGroup({
   busy,
   buttonLabelPrefix,
   onReuseImage,
-  previewUrls,
   reusingImageIds,
   sources,
   title,
@@ -117,7 +250,6 @@ function ImageReuseGroup({
       <p className="image-reuse-group-title">{title}</p>
       <div className="image-reuse-list">
         {sources.map((source) => {
-          const previewUrl = source.kind === "upload" ? previewUrls.get(source.id) : source.contentUrl;
           const isReusing = reusingImageIds.includes(source.id);
 
           return (
@@ -129,14 +261,12 @@ function ImageReuseGroup({
               onClick={() => void onReuseImage(source)}
               type="button"
             >
-              {previewUrl ? (
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  className="image-reuse-item-thumb"
-                  src={previewUrl}
-                />
-              ) : null}
+              <img
+                alt=""
+                aria-hidden="true"
+                className="image-reuse-item-thumb"
+                src={source.contentUrl}
+              />
               <span className="image-reuse-item-name" title={source.name}>
                 {source.name}
               </span>

--- a/apps/frontend/src/features/imagegen/components/ImageWorkspace.tsx
+++ b/apps/frontend/src/features/imagegen/components/ImageWorkspace.tsx
@@ -53,6 +53,7 @@ export function ImageWorkspace({
         onResolutionChange={workspace.handleResolutionChange}
         onReuseImage={workspace.reuseImage}
         onSubmit={workspace.handleSubmit}
+        mode={workspace.mode}
         prompt={workspace.prompt}
         referenceImages={workspace.referenceImages}
         reusableImages={workspace.reusableImages}

--- a/apps/frontend/src/features/imagegen/constants.ts
+++ b/apps/frontend/src/features/imagegen/constants.ts
@@ -9,7 +9,4 @@ export const referenceImageInputAccept = "image/png,image/jpeg,image/webp,image/
 
 export const maxReferenceImageBytes = 20 * 1024 * 1024;
 
-export const imagePromptPlaceholder =
-  "Describe the image you want to generate. Shift + Enter to generate.";
-
 export const imageToastDurationMs = 3000;

--- a/apps/frontend/src/features/imagegen/test/imageWorkspaceTestContext.tsx
+++ b/apps/frontend/src/features/imagegen/test/imageWorkspaceTestContext.tsx
@@ -21,6 +21,16 @@ export function setupImageWorkspaceTestContext() {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.stubGlobal("fetch", mockedFetch);
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      writable: true,
+      value: vi.fn(() => `blob:mock-${Math.random().toString(36).slice(2)}`),
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      writable: true,
+      value: vi.fn(),
+    });
     imageStreamHandlers = undefined;
     mockedFetch.mockReset();
     mockedFetch.mockResolvedValue(createVersionResponse(currentFrontendVersion));

--- a/apps/frontend/src/features/imagegen/test/registerImageWorkspaceSuite.tsx
+++ b/apps/frontend/src/features/imagegen/test/registerImageWorkspaceSuite.tsx
@@ -2,24 +2,28 @@ import { act, fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { expect, it, vi } from "vitest";
 
-import { imagePromptPlaceholder, imageToastDurationMs, referenceImageInputAccept } from "../constants";
+import { imageToastDurationMs, referenceImageInputAccept } from "../constants";
 import type { ImageWorkspaceTestContext } from "./imageWorkspaceTestContext";
 
 export function registerImageWorkspaceSuite(context: ImageWorkspaceTestContext) {
-  it("renders the image workspace with prompt and Generate button when New image is selected", async () => {
+  it("renders the image workspace with prompt and Generate button when New Image is selected", async () => {
     context.renderApp();
     await context.waitForReady();
 
     await userEvent.click(screen.getByRole("button", { name: "New" }));
-    await userEvent.click(screen.getByRole("menuitem", { name: "New image" }));
+    await userEvent.click(screen.getByRole("menuitem", { name: "New Image" }));
 
     await context.waitForImageReady();
 
     const promptInput = screen.getByLabelText("Image prompt");
     expect(promptInput).toBeInTheDocument();
-    expect(promptInput).toHaveAttribute("placeholder", imagePromptPlaceholder);
+    expect(promptInput).toHaveAttribute(
+      "placeholder",
+      "Describe the result you want. Add reference images from file or this session when you want the next image to follow or edit them. Shift + Enter to generate.",
+    );
 
     expect(screen.getByRole("button", { name: "Generate" })).toBeInTheDocument();
+    expect(screen.getByText("Generate", { selector: ".image-composer-mode-badge" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Send" })).not.toBeInTheDocument();
   });
 
@@ -28,7 +32,7 @@ export function registerImageWorkspaceSuite(context: ImageWorkspaceTestContext) 
     await context.waitForReady();
 
     await userEvent.click(screen.getByRole("button", { name: "New" }));
-    await userEvent.click(screen.getByRole("menuitem", { name: "New image" }));
+    await userEvent.click(screen.getByRole("menuitem", { name: "New Image" }));
 
     await context.waitForImageReady();
 
@@ -40,7 +44,7 @@ export function registerImageWorkspaceSuite(context: ImageWorkspaceTestContext) 
     await context.waitForReady();
 
     await userEvent.click(screen.getByRole("button", { name: "New" }));
-    await userEvent.click(screen.getByRole("menuitem", { name: "New image" }));
+    await userEvent.click(screen.getByRole("menuitem", { name: "New Image" }));
 
     await context.waitForImageReady();
 
@@ -58,7 +62,7 @@ export function registerImageWorkspaceSuite(context: ImageWorkspaceTestContext) 
     await context.waitForReady();
 
     await user.click(screen.getByRole("button", { name: "New" }));
-    await user.click(screen.getByRole("menuitem", { name: "New image" }));
+    await user.click(screen.getByRole("menuitem", { name: "New Image" }));
 
     await context.waitForImageReady();
 
@@ -84,7 +88,7 @@ export function registerImageWorkspaceSuite(context: ImageWorkspaceTestContext) 
     await context.waitForReady();
 
     await user.click(screen.getByRole("button", { name: "New" }));
-    await user.click(screen.getByRole("menuitem", { name: "New image" }));
+    await user.click(screen.getByRole("menuitem", { name: "New Image" }));
 
     await context.waitForImageReady();
 
@@ -104,7 +108,7 @@ export function registerImageWorkspaceSuite(context: ImageWorkspaceTestContext) 
     await context.waitForReady();
 
     await user.click(screen.getByRole("button", { name: "New" }));
-    await user.click(screen.getByRole("menuitem", { name: "New image" }));
+    await user.click(screen.getByRole("menuitem", { name: "New Image" }));
 
     await context.waitForImageReady();
 
@@ -186,7 +190,7 @@ export function registerImageWorkspaceSuite(context: ImageWorkspaceTestContext) 
     await context.waitForReady();
 
     await user.click(screen.getByRole("button", { name: "New" }));
-    await user.click(screen.getByRole("menuitem", { name: "New image" }));
+    await user.click(screen.getByRole("menuitem", { name: "New Image" }));
 
     await context.waitForImageReady();
 
@@ -238,7 +242,7 @@ export function registerImageWorkspaceSuite(context: ImageWorkspaceTestContext) 
     await context.waitForReady();
 
     await user.click(screen.getByRole("button", { name: "New" }));
-    await user.click(screen.getByRole("menuitem", { name: "New image" }));
+    await user.click(screen.getByRole("menuitem", { name: "New Image" }));
 
     await context.waitForImageReady();
 
@@ -248,6 +252,10 @@ export function registerImageWorkspaceSuite(context: ImageWorkspaceTestContext) 
     ) as HTMLInputElement;
     expect(imageFileInput).not.toBeNull();
     fireEvent.change(imageFileInput, { target: { files: [referenceFile] } });
+
+    await waitFor(() => {
+      expect(screen.getByText("Edit")).toBeInTheDocument();
+    });
 
     await user.type(screen.getByLabelText("Image prompt"), "Edit this image");
     await user.click(screen.getByRole("button", { name: "Generate" }));
@@ -263,7 +271,7 @@ export function registerImageWorkspaceSuite(context: ImageWorkspaceTestContext) 
     });
   });
 
-  it("reuses a previous uploaded reference image only after the user explicitly reattaches it", async () => {
+  it("uses From File when the user wants to reattach an earlier upload", async () => {
     context.mockSuccessfulCreateImageGeneration();
     const user = userEvent.setup();
 
@@ -271,7 +279,7 @@ export function registerImageWorkspaceSuite(context: ImageWorkspaceTestContext) 
     await context.waitForReady();
 
     await user.click(screen.getByRole("button", { name: "New" }));
-    await user.click(screen.getByRole("menuitem", { name: "New image" }));
+    await user.click(screen.getByRole("menuitem", { name: "New Image" }));
 
     await context.waitForImageReady();
 
@@ -311,12 +319,6 @@ export function registerImageWorkspaceSuite(context: ImageWorkspaceTestContext) 
       });
     });
 
-    await waitFor(() => {
-      expect(
-        screen.getByRole("button", { name: "Attach previous upload earlier-ref.png" }),
-      ).toBeInTheDocument();
-    });
-
     await user.type(screen.getByLabelText("Image prompt"), "Do not reuse implicitly");
     await user.click(screen.getByRole("button", { name: "Generate" }));
 
@@ -346,7 +348,9 @@ export function registerImageWorkspaceSuite(context: ImageWorkspaceTestContext) 
       });
     });
 
-    await user.click(screen.getByRole("button", { name: "Attach previous upload earlier-ref.png" }));
+    await user.click(screen.getByRole("button", { name: "Add reference images" }));
+    await user.click(screen.getByRole("menuitem", { name: "From File" }));
+    fireEvent.change(imageFileInput, { target: { files: [referenceFile] } });
 
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Remove earlier-ref.png" })).toBeInTheDocument();
@@ -396,7 +400,7 @@ export function registerImageWorkspaceSuite(context: ImageWorkspaceTestContext) 
     await context.waitForReady();
 
     await user.click(screen.getByRole("button", { name: "New" }));
-    await user.click(screen.getByRole("menuitem", { name: "New image" }));
+    await user.click(screen.getByRole("menuitem", { name: "New Image" }));
 
     await context.waitForImageReady();
 
@@ -441,6 +445,9 @@ export function registerImageWorkspaceSuite(context: ImageWorkspaceTestContext) 
         ],
       });
     });
+
+    await user.click(screen.getByRole("button", { name: "Add reference images" }));
+    await user.click(screen.getByRole("menuitem", { name: "From Session" }));
 
     await waitFor(() => {
       expect(
@@ -508,7 +515,7 @@ export function registerImageWorkspaceSuite(context: ImageWorkspaceTestContext) 
     await context.waitForReady();
 
     await user.click(screen.getByRole("button", { name: "New" }));
-    await user.click(screen.getByRole("menuitem", { name: "New image" }));
+    await user.click(screen.getByRole("menuitem", { name: "New Image" }));
 
     await context.waitForImageReady();
 
@@ -548,13 +555,16 @@ export function registerImageWorkspaceSuite(context: ImageWorkspaceTestContext) 
       });
     });
 
+    await user.type(screen.getByLabelText("Image prompt"), "Try to submit while reusing");
+    await user.click(screen.getByRole("button", { name: "Add reference images" }));
+    await user.click(screen.getByRole("menuitem", { name: "From Session" }));
+
     await waitFor(() => {
       expect(
         screen.getByRole("button", { name: "Attach generated image generated-output.png" }),
       ).toBeInTheDocument();
     });
 
-    await user.type(screen.getByLabelText("Image prompt"), "Try to submit while reusing");
     await user.click(screen.getByRole("button", { name: "Attach generated image generated-output.png" }));
 
     await waitFor(() => {
@@ -564,7 +574,7 @@ export function registerImageWorkspaceSuite(context: ImageWorkspaceTestContext) 
     });
 
     await user.click(screen.getByRole("button", { name: "New" }));
-    await user.click(screen.getByRole("menuitem", { name: "New image" }));
+    await user.click(screen.getByRole("menuitem", { name: "New Image" }));
 
     await context.waitForImageReady();
 
@@ -610,7 +620,7 @@ export function registerImageWorkspaceSuite(context: ImageWorkspaceTestContext) 
     await context.waitForReady();
 
     await user.click(screen.getByRole("button", { name: "New" }));
-    await user.click(screen.getByRole("menuitem", { name: "New image" }));
+    await user.click(screen.getByRole("menuitem", { name: "New Image" }));
 
     await context.waitForImageReady();
 
@@ -650,12 +660,19 @@ export function registerImageWorkspaceSuite(context: ImageWorkspaceTestContext) 
       });
     });
 
-    const attachButton = await screen.findByRole("button", {
+    const attachmentMenuButton = await screen.findByRole("button", {
+      name: "Add reference images",
+    });
+
+    fireEvent.click(attachmentMenuButton);
+    fireEvent.click(await screen.findByRole("menuitem", { name: "From Session" }));
+
+    const generatedAttachButton = await screen.findByRole("button", {
       name: "Attach generated image generated-output.png",
     });
 
-    fireEvent.click(attachButton);
-    fireEvent.click(attachButton);
+    fireEvent.click(generatedAttachButton);
+    fireEvent.click(generatedAttachButton);
 
     expect(context.mockedFetch).toHaveBeenCalledTimes(2);
 
@@ -669,26 +686,46 @@ export function registerImageWorkspaceSuite(context: ImageWorkspaceTestContext) 
     });
   });
 
-  it("applies the reference-image limit when reusing a prior image", async () => {
+  it("applies the reference-image limit when reusing a prior generated image", async () => {
     context.mockSuccessfulCreateImageGeneration();
     const user = userEvent.setup();
+    const generatedImageUrl =
+      "http://localhost:8080/api/v1/sessions/22222222-2222-2222-2222-222222222222/image-generations/gen-44444444-4444-4444-4444-444444444444/images/asset-001/content";
+
+    context.mockedFetch.mockImplementation(async (input) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+
+      if (url === generatedImageUrl) {
+        return createImageContentResponse();
+      }
+
+      return new Response(JSON.stringify({ version: "test-version" }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+    });
 
     const { container } = context.renderApp();
     await context.waitForReady();
 
     await user.click(screen.getByRole("button", { name: "New" }));
-    await user.click(screen.getByRole("menuitem", { name: "New image" }));
+    await user.click(screen.getByRole("menuitem", { name: "New Image" }));
 
     await context.waitForImageReady();
 
-    const earlierReferenceFile = new File(["earlier"], "earlier-ref.png", { type: "image/png" });
     const imageFileInput = container.querySelector(
       `input[type="file"][accept="${referenceImageInputAccept}"]`,
     ) as HTMLInputElement;
     expect(imageFileInput).not.toBeNull();
-    fireEvent.change(imageFileInput, { target: { files: [earlierReferenceFile] } });
 
-    await user.type(screen.getByLabelText("Image prompt"), "Create reusable upload");
+    await user.type(screen.getByLabelText("Image prompt"), "Create reusable output");
     await user.click(screen.getByRole("button", { name: "Generate" }));
 
     await waitFor(() => {
@@ -699,15 +736,28 @@ export function registerImageWorkspaceSuite(context: ImageWorkspaceTestContext) 
       context.requireImageStreamHandlers().onCompleted?.({
         generationId: "gen-44444444-4444-4444-4444-444444444444",
         sessionId: "22222222-2222-2222-2222-222222222222",
-        mode: "image_edit",
+        mode: "text_to_image",
         status: "completed",
-        prompt: "Create reusable upload",
+        prompt: "Create reusable output",
         resolution: { key: "1024x1024", width: 1024, height: 1024 },
         outputImageCount: 1,
         createdAt: "2026-03-31T10:01:00Z",
         completedAt: "2026-03-31T10:01:05Z",
         inputAssets: [],
-        outputAssets: [],
+        outputAssets: [
+          {
+            assetId: "asset-001",
+            filename: "generated-output.png",
+            mediaType: "image/png",
+            sizeBytes: 12345,
+            sha256: "abc123",
+            width: 1024,
+            height: 1024,
+            createdAt: "2026-03-31T10:01:05Z",
+            contentUrl:
+              "/api/v1/sessions/22222222-2222-2222-2222-222222222222/image-generations/gen-44444444-4444-4444-4444-444444444444/images/asset-001/content",
+          },
+        ],
       });
     });
 
@@ -720,13 +770,15 @@ export function registerImageWorkspaceSuite(context: ImageWorkspaceTestContext) 
       expect(screen.getByRole("button", { name: "Remove draft-4.png" })).toBeInTheDocument();
     });
 
-    await user.click(screen.getByRole("button", { name: "Attach previous upload earlier-ref.png" }));
+    await user.click(screen.getByRole("button", { name: "Add reference images" }));
+    await user.click(screen.getByRole("menuitem", { name: "From Session" }));
+    await user.click(screen.getByRole("button", { name: "Attach generated image generated-output.png" }));
 
     await waitFor(() => {
       expect(screen.getByText(/at most 4 reference images/i)).toBeInTheDocument();
     });
 
-    expect(screen.queryByRole("button", { name: "Remove earlier-ref.png" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Remove generated-output.png" })).not.toBeInTheDocument();
   });
 
   it("submits on Shift+Enter", async () => {
@@ -736,7 +788,7 @@ export function registerImageWorkspaceSuite(context: ImageWorkspaceTestContext) 
     await context.waitForReady();
 
     await userEvent.click(screen.getByRole("button", { name: "New" }));
-    await userEvent.click(screen.getByRole("menuitem", { name: "New image" }));
+    await userEvent.click(screen.getByRole("menuitem", { name: "New Image" }));
 
     await context.waitForImageReady();
 
@@ -760,7 +812,7 @@ export function registerImageWorkspaceSuite(context: ImageWorkspaceTestContext) 
     await context.waitForReady();
 
     await userEvent.click(screen.getByRole("button", { name: "New" }));
-    await userEvent.click(screen.getByRole("menuitem", { name: "New image" }));
+    await userEvent.click(screen.getByRole("menuitem", { name: "New Image" }));
 
     await context.waitForImageReady();
 
@@ -786,7 +838,7 @@ export function registerImageWorkspaceSuite(context: ImageWorkspaceTestContext) 
     await context.waitForReady();
 
     await userEvent.click(screen.getByRole("button", { name: "New" }));
-    await userEvent.click(screen.getByRole("menuitem", { name: "New image" }));
+    await userEvent.click(screen.getByRole("menuitem", { name: "New Image" }));
 
     await context.waitForImageReady();
 
@@ -820,14 +872,14 @@ export function registerImageWorkspaceSuite(context: ImageWorkspaceTestContext) 
     }
   });
 
-  it("creates a fresh session and clears draft state when New image is selected again", async () => {
+  it("creates a fresh session and clears draft state when New Image is selected again", async () => {
     context.mockSuccessfulCreateImageGeneration();
 
     context.renderApp();
     await context.waitForReady();
 
     await userEvent.click(screen.getByRole("button", { name: "New" }));
-    await userEvent.click(screen.getByRole("menuitem", { name: "New image" }));
+    await userEvent.click(screen.getByRole("menuitem", { name: "New Image" }));
 
     await context.waitForImageReady();
 
@@ -837,9 +889,9 @@ export function registerImageWorkspaceSuite(context: ImageWorkspaceTestContext) 
 
     const initialImageSessionCalls = context.mockedCreateSession.mock.calls.length;
 
-    // Click New image again
+    // Click New Image again
     await userEvent.click(screen.getByRole("button", { name: "New" }));
-    await userEvent.click(screen.getByRole("menuitem", { name: "New image" }));
+    await userEvent.click(screen.getByRole("menuitem", { name: "New Image" }));
 
     await context.waitForImageReady();
 
@@ -857,7 +909,7 @@ export function registerImageWorkspaceSuite(context: ImageWorkspaceTestContext) 
     await context.waitForReady();
 
     await userEvent.click(screen.getByRole("button", { name: "New" }));
-    await userEvent.click(screen.getByRole("menuitem", { name: "New image" }));
+    await userEvent.click(screen.getByRole("menuitem", { name: "New Image" }));
 
     await context.waitForImageReady();
 
@@ -870,7 +922,7 @@ export function registerImageWorkspaceSuite(context: ImageWorkspaceTestContext) 
 
     // Start a new image session
     await userEvent.click(screen.getByRole("button", { name: "New" }));
-    await userEvent.click(screen.getByRole("menuitem", { name: "New image" }));
+    await userEvent.click(screen.getByRole("menuitem", { name: "New Image" }));
 
     await context.waitForImageReady();
 
@@ -884,7 +936,7 @@ export function registerImageWorkspaceSuite(context: ImageWorkspaceTestContext) 
     await context.waitForReady();
 
     await userEvent.click(screen.getByRole("button", { name: "New" }));
-    await userEvent.click(screen.getByRole("menuitem", { name: "New image" }));
+    await userEvent.click(screen.getByRole("menuitem", { name: "New Image" }));
 
     await context.waitForImageReady();
 
@@ -909,7 +961,7 @@ export function registerImageWorkspaceSuite(context: ImageWorkspaceTestContext) 
     await context.waitForReady();
 
     await userEvent.click(screen.getByRole("button", { name: "New" }));
-    await userEvent.click(screen.getByRole("menuitem", { name: "New image" }));
+    await userEvent.click(screen.getByRole("menuitem", { name: "New Image" }));
 
     await context.waitForImageReady();
 
@@ -948,7 +1000,7 @@ export function registerImageWorkspaceSuite(context: ImageWorkspaceTestContext) 
     await context.waitForReady();
 
     await userEvent.click(screen.getByRole("button", { name: "New" }));
-    await userEvent.click(screen.getByRole("menuitem", { name: "New image" }));
+    await userEvent.click(screen.getByRole("menuitem", { name: "New Image" }));
 
     await context.waitForImageReady();
 
@@ -966,7 +1018,7 @@ export function registerImageWorkspaceSuite(context: ImageWorkspaceTestContext) 
     await context.waitForReady();
 
     await user.click(screen.getByRole("button", { name: "New" }));
-    await user.click(screen.getByRole("menuitem", { name: "New image" }));
+    await user.click(screen.getByRole("menuitem", { name: "New Image" }));
 
     await context.waitForImageReady();
 

--- a/apps/frontend/src/features/imagegen/types.ts
+++ b/apps/frontend/src/features/imagegen/types.ts
@@ -41,11 +41,10 @@ export type ImageTurnOutputImage = {
 
 export type ReusableImageSource = {
   id: string;
-  kind: ImageReferenceSourceKind;
+  kind: "generated";
   name: string;
   mediaType: string;
-  file?: File;
-  contentUrl?: string;
+  contentUrl: string;
 };
 
 export type ImageTurn = {

--- a/apps/frontend/src/features/imagegen/useImageWorkspace.ts
+++ b/apps/frontend/src/features/imagegen/useImageWorkspace.ts
@@ -84,17 +84,6 @@ export function useImageWorkspace(capabilities: ImageGenerationCapabilitiesRespo
   const reusableImages = useMemo<ReusableImageSource[]>(
     () => [
       ...turns.flatMap((turn) =>
-        turn.referenceImages
-          .filter((image) => image.sourceKind === "upload")
-          .map((image) => ({
-            id: `${turn.id}:reference:${image.id}`,
-            kind: "upload" as const,
-            name: image.name,
-            mediaType: image.file.type,
-            file: image.file,
-          })),
-      ),
-      ...turns.flatMap((turn) =>
         turn.outputImages.map((image) => ({
           id: `${turn.id}:output:${image.assetId}`,
           kind: "generated" as const,
@@ -335,15 +324,6 @@ export function useImageWorkspace(capabilities: ImageGenerationCapabilitiesRespo
 
   async function reuseImage(source: ReusableImageSource) {
     if (busy) {
-      return;
-    }
-
-    if (source.kind === "upload" && source.file) {
-      tryAddReferenceImages([createSelectedReferenceImage(source.file, "upload")]);
-      return;
-    }
-
-    if (source.kind !== "generated" || !source.contentUrl) {
       return;
     }
 

--- a/apps/frontend/src/styles/imagegen.css
+++ b/apps/frontend/src/styles/imagegen.css
@@ -111,6 +111,30 @@
   border-bottom: 0;
 }
 
+.image-composer .composer-input {
+  padding-right: 128px;
+}
+
+.image-composer-mode-badge {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 5.5rem;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(195, 77, 30, 0.1);
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  z-index: 1;
+}
+
 .image-composer-controls {
   display: flex;
   flex-wrap: wrap;
@@ -172,19 +196,113 @@
   color: var(--danger);
 }
 
+.image-reuse-anchor {
+  position: relative;
+  display: inline-flex;
+  flex-shrink: 0;
+}
+
+.image-reference-menu {
+  position: absolute;
+  left: 0;
+  bottom: calc(100% + 12px);
+  min-width: 160px;
+  display: grid;
+  gap: 2px;
+  padding: 8px;
+  border: 1px solid rgba(56, 44, 30, 0.1);
+  border-radius: 18px;
+  background: rgba(255, 251, 247, 0.96);
+  box-shadow: 0 20px 48px rgba(64, 41, 15, 0.16);
+  z-index: 20;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(6px);
+  transition:
+    opacity 160ms ease,
+    transform 160ms ease;
+  visibility: hidden;
+}
+
+.image-reference-menu[data-open="true"] {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+  visibility: visible;
+}
+
+.image-reference-menu-item {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 10px 14px;
+  border: 0;
+  border-radius: 12px;
+  background: transparent;
+  color: var(--ink);
+  font-size: 0.88rem;
+  text-align: left;
+  cursor: pointer;
+}
+
+.image-reference-menu-item:hover,
+.image-reference-menu-item:focus-visible {
+  background: var(--surface-hover, rgba(64, 41, 15, 0.06));
+  outline: none;
+}
+
+.image-reference-menu-item[aria-disabled="true"] {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.image-reference-menu-item[aria-disabled="true"]:hover,
+.image-reference-menu-item[aria-disabled="true"]:focus-visible {
+  background: transparent;
+}
+
 .image-reuse-panel {
+  position: absolute;
+  left: 0;
+  bottom: calc(100% + 12px);
+  width: min(640px, calc(100vw - 96px));
+  max-height: min(360px, calc(100dvh - 220px));
   display: grid;
   gap: 12px;
-  margin-top: 12px;
   padding: 14px 16px;
   border: 1px solid rgba(56, 44, 30, 0.1);
   border-radius: 20px;
-  background: rgba(255, 255, 255, 0.78);
+  background: rgba(255, 251, 247, 0.96);
+  box-shadow: 0 20px 48px rgba(64, 41, 15, 0.16);
+  overflow: auto;
+  z-index: 20;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(6px);
+  transition:
+    opacity 160ms ease,
+    transform 160ms ease;
+  visibility: hidden;
+}
+
+.image-reuse-panel[data-open="true"] {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+  visibility: visible;
 }
 
 .image-reuse-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.image-reuse-header-copy {
   display: grid;
   gap: 4px;
+  min-width: 0;
 }
 
 .image-reuse-title,
@@ -199,6 +317,38 @@
 .image-reuse-description {
   font-size: 0.85rem;
   color: var(--muted);
+}
+
+.image-reuse-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  min-width: 34px;
+  height: 34px;
+  padding: 0;
+  border: 0;
+  border-radius: 999px;
+  background: rgba(56, 44, 30, 0.06);
+  color: var(--muted);
+  cursor: pointer;
+}
+
+.image-reuse-close:hover,
+.image-reuse-close:focus-visible {
+  background: rgba(56, 44, 30, 0.12);
+  color: var(--ink);
+  outline: none;
+}
+
+.image-reuse-close svg {
+  width: 16px;
+  height: 16px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2.2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .image-reuse-group {
@@ -249,4 +399,10 @@
 .image-reuse-item-action {
   font-size: 0.8rem;
   color: var(--accent);
+}
+
+.image-reuse-empty {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--muted);
 }

--- a/apps/frontend/src/styles/layout.css
+++ b/apps/frontend/src/styles/layout.css
@@ -192,7 +192,7 @@
   position: absolute;
   top: calc(100% + 10px);
   right: 0;
-  min-width: 148px;
+  min-width: 132px;
   display: grid;
   gap: 2px;
   padding: 8px;

--- a/apps/frontend/src/styles/responsive.css
+++ b/apps/frontend/src/styles/responsive.css
@@ -71,9 +71,25 @@
     margin-left: 0;
     align-self: center;
   }
+
+  .image-reference-menu,
+  .image-reuse-panel {
+    width: min(560px, calc(100vw - 40px));
+  }
+
+  .image-reuse-panel {
+    max-height: min(320px, calc(100dvh - 200px));
+  }
 }
 
 @media (max-width: 720px) {
+  .image-reference-menu,
+  .image-reuse-panel {
+    left: auto;
+    right: 0;
+    width: min(480px, calc(100vw - 40px));
+  }
+
   .composer-footer-end {
     width: 100%;
     justify-content: flex-end;


### PR DESCRIPTION
## Summary
- move image composer mode state into the input area and collapse guidance into the prompt placeholder
- replace the reference attachment flow with a compact icon-only source menu and session-generated image picker
- tighten the New menu labels/width and remove dead image reuse code paths

## Verification
- `cd apps/frontend && npm test`
- `cd apps/frontend && npm run build`