### PR TITLE
Fix FLUX image edit reference payload

### DIFF
--- a/apps/backend/internal/azurefoundry/client.go
+++ b/apps/backend/internal/azurefoundry/client.go
@@ -156,14 +156,43 @@ type textToImageRequest struct {
 }
 
 type imageEditRequest struct {
-	Prompt       string   `json:"prompt"`
-	ImagePrompt  string   `json:"image_prompt,omitempty"`  // single base64-encoded image
-	ImagePrompts []string `json:"image_prompts,omitempty"` // multiple base64-encoded images
-	Width        int      `json:"width,omitempty"`
-	Height       int      `json:"height,omitempty"`
-	OutputFormat string   `json:"output_format,omitempty"`
-	NumImages    int      `json:"num_images,omitempty"`
-	Model        string   `json:"model,omitempty"`
+	Prompt       string
+	InputImages  []string
+	Width        int
+	Height       int
+	OutputFormat string
+	NumImages    int
+	Model        string
+}
+
+func (r imageEditRequest) MarshalJSON() ([]byte, error) {
+	payload := map[string]any{
+		"prompt": r.Prompt,
+	}
+	if r.Width > 0 {
+		payload["width"] = r.Width
+	}
+	if r.Height > 0 {
+		payload["height"] = r.Height
+	}
+	if strings.TrimSpace(r.OutputFormat) != "" {
+		payload["output_format"] = r.OutputFormat
+	}
+	if r.NumImages > 0 {
+		payload["num_images"] = r.NumImages
+	}
+	if strings.TrimSpace(r.Model) != "" {
+		payload["model"] = r.Model
+	}
+	for i, img := range r.InputImages {
+		key := "input_image"
+		if i > 0 {
+			key = fmt.Sprintf("input_image_%d", i+1)
+		}
+		payload[key] = img
+	}
+
+	return json.Marshal(payload)
 }
 
 // fluxImage represents one image entry in a synchronous provider response.
@@ -402,17 +431,10 @@ func (c *Client) buildImageEditPayload(req imageprovider.GenerateRequest) imageE
 		OutputFormat: req.OutputFormat,
 		NumImages:    n,
 		Model:        c.model,
+		InputImages:  make([]string, 0, len(req.InputImages)),
 	}
-	switch len(req.InputImages) {
-	case 0:
-		// no reference images
-	case 1:
-		r.ImagePrompt = base64.StdEncoding.EncodeToString(req.InputImages[0])
-	default:
-		r.ImagePrompts = make([]string, len(req.InputImages))
-		for i, img := range req.InputImages {
-			r.ImagePrompts[i] = base64.StdEncoding.EncodeToString(img)
-		}
+	for _, img := range req.InputImages {
+		r.InputImages = append(r.InputImages, base64.StdEncoding.EncodeToString(img))
 	}
 	return r
 }

--- a/apps/backend/internal/azurefoundry/client_test.go
+++ b/apps/backend/internal/azurefoundry/client_test.go
@@ -343,11 +343,17 @@ func TestGenerateEncodesImageEditPayloadWithSingleImage(t *testing.T) {
 	if err := json.Unmarshal(capturedBody, &body); err != nil {
 		t.Fatalf("json.Unmarshal(capturedBody) error = %v", err)
 	}
-	if body["image_prompt"] != wantEncoded {
-		t.Errorf("image_prompt = %q, want base64 of input image", body["image_prompt"])
+	if body["input_image"] != wantEncoded {
+		t.Errorf("input_image = %q, want base64 of input image", body["input_image"])
+	}
+	if _, ok := body["input_image_2"]; ok {
+		t.Error("input_image_2 should not be set for a single image")
+	}
+	if _, ok := body["image_prompt"]; ok {
+		t.Error("image_prompt should not be sent to FLUX image edit")
 	}
 	if _, ok := body["image_prompts"]; ok {
-		t.Error("image_prompts should not be set for single image")
+		t.Error("image_prompts should not be sent to FLUX image edit")
 	}
 }
 
@@ -377,18 +383,20 @@ func TestGenerateEncodesImageEditPayloadWithMultipleImages(t *testing.T) {
 	if err := json.Unmarshal(capturedBody, &body); err != nil {
 		t.Fatalf("json.Unmarshal(capturedBody) error = %v", err)
 	}
+	if body["input_image"] != base64.StdEncoding.EncodeToString(img1) {
+		t.Errorf("input_image = %q", body["input_image"])
+	}
+	if body["input_image_2"] != base64.StdEncoding.EncodeToString(img2) {
+		t.Errorf("input_image_2 = %q", body["input_image_2"])
+	}
+	if _, ok := body["input_image_3"]; ok {
+		t.Error("input_image_3 should not be set when only two images are provided")
+	}
 	if _, ok := body["image_prompt"]; ok {
-		t.Error("image_prompt should not be set for multiple images")
+		t.Error("image_prompt should not be sent to FLUX image edit")
 	}
-	prompts, ok := body["image_prompts"].([]any)
-	if !ok || len(prompts) != 2 {
-		t.Fatalf("image_prompts = %v", body["image_prompts"])
-	}
-	if prompts[0] != base64.StdEncoding.EncodeToString(img1) {
-		t.Errorf("image_prompts[0] = %q", prompts[0])
-	}
-	if prompts[1] != base64.StdEncoding.EncodeToString(img2) {
-		t.Errorf("image_prompts[1] = %q", prompts[1])
+	if _, ok := body["image_prompts"]; ok {
+		t.Error("image_prompts should not be sent to FLUX image edit")
 	}
 }
 


### PR DESCRIPTION
## Summary
- send FLUX image-edit reference images using `input_image`, `input_image_2`, and related fields expected by Azure Foundry FLUX.2
- keep the request builder provider-specific via custom JSON marshaling in the Foundry adapter
- update adapter tests to prevent regressions back to the legacy `image_prompt` payload shape

## Verification
- `GOCACHE=/tmp/ulduar-go-build go test ./internal/azurefoundry/...`
- `GOCACHE=/tmp/ulduar-go-build go test ./...`