### PR TITLE
Show generated images as thumbnails with download action

### DIFF
--- a/apps/frontend/src/features/chat/components/icons.tsx
+++ b/apps/frontend/src/features/chat/components/icons.tsx
@@ -64,6 +64,16 @@ export function IconSpinner() {
   );
 }
 
+export function IconDownload() {
+  return (
+    <svg aria-hidden="true" className="button-icon" viewBox="0 0 24 24">
+      <path d="M12 4v10" />
+      <path d="m8 10 4 4 4-4" />
+      <path d="M5 18h14" />
+    </svg>
+  );
+}
+
 export function IconClose() {
   return (
     <svg aria-hidden="true" viewBox="0 0 24 24">

--- a/apps/frontend/src/features/imagegen/components/ImageTurnCard.tsx
+++ b/apps/frontend/src/features/imagegen/components/ImageTurnCard.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
-import { IconSpinner } from "../../chat/components/icons";
-import type { ImageTurn } from "../types";
+import { ActionTooltip } from "../../chat/components/ActionTooltip";
+import { IconDownload, IconSpinner } from "../../chat/components/icons";
+import type { ImageTurn, ImageTurnOutputImage } from "../types";
 
 type ImageTurnCardProps = {
   turn: ImageTurn;
@@ -68,14 +69,7 @@ export function ImageTurnCard({ turn }: ImageTurnCardProps) {
       {turn.status === "completed" && turn.outputImages.length > 0 ? (
         <div className="image-turn-outputs">
           {turn.outputImages.map((img) => (
-            <img
-              key={img.assetId}
-              className="image-turn-output"
-              src={img.contentUrl}
-              alt={img.filename}
-              loading="lazy"
-              decoding="async"
-            />
+            <ImageTurnOutputCard key={img.assetId} image={img} />
           ))}
         </div>
       ) : null}
@@ -85,4 +79,103 @@ export function ImageTurnCard({ turn }: ImageTurnCardProps) {
       ) : null}
     </article>
   );
+}
+
+type ImageTurnOutputCardProps = {
+  image: ImageTurnOutputImage;
+};
+
+function ImageTurnOutputCard({ image }: ImageTurnOutputCardProps) {
+  const [downloadState, setDownloadState] = useState<"idle" | "downloading" | "failed">("idle");
+  const resolutionLabel = formatResolutionLabel(image);
+
+  async function handleDownload() {
+    if (downloadState === "downloading") {
+      return;
+    }
+
+    setDownloadState("downloading");
+
+    try {
+      const response = await fetch(image.contentUrl);
+      if (!response.ok) {
+        throw new Error(`download failed with status ${response.status}`);
+      }
+
+      const blob = await response.blob();
+      const downloadUrl = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = downloadUrl;
+      link.download = image.filename;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.setTimeout(() => {
+        URL.revokeObjectURL(downloadUrl);
+      }, 1000);
+      setDownloadState("idle");
+    } catch {
+      setDownloadState("failed");
+    }
+  }
+
+  return (
+    <figure className="image-turn-output-card">
+      <div className="image-turn-output-frame">
+        <img
+          className="image-turn-output"
+          src={image.contentUrl}
+          alt={image.filename}
+          loading="lazy"
+          decoding="async"
+        />
+      </div>
+      <div
+        className="image-turn-output-toolbar"
+        role="toolbar"
+        aria-label={`Generated image actions for ${image.filename}`}
+      >
+        <span className="image-turn-output-meta">{resolutionLabel}</span>
+        <div className="image-turn-output-actions">
+          {downloadState === "failed" ? (
+            <span className="image-turn-output-feedback" role="status">
+              Download failed
+            </span>
+          ) : null}
+          <ActionTooltip
+            tooltipClassName="message-action-tooltip"
+            content={
+              <span className="action-tooltip-label message-action-tooltip-label">
+                {downloadState === "downloading" ? "Downloading original" : "Download original"}
+              </span>
+            }
+          >
+            <button
+              type="button"
+              className="message-toolbar-button"
+              aria-label={
+                downloadState === "downloading"
+                  ? `Downloading original generated image ${image.filename}`
+                  : `Download original generated image ${image.filename}`
+              }
+              onClick={() => {
+                void handleDownload();
+              }}
+              disabled={downloadState === "downloading"}
+            >
+              {downloadState === "downloading" ? <IconSpinner /> : <IconDownload />}
+            </button>
+          </ActionTooltip>
+        </div>
+      </div>
+    </figure>
+  );
+}
+
+function formatResolutionLabel(image: ImageTurnOutputImage): string {
+  if (image.width && image.height) {
+    return `Original ${image.width} x ${image.height}`;
+  }
+
+  return image.filename;
 }

--- a/apps/frontend/src/features/imagegen/test/registerImageWorkspaceSuite.tsx
+++ b/apps/frontend/src/features/imagegen/test/registerImageWorkspaceSuite.tsx
@@ -176,10 +176,106 @@ export function registerImageWorkspaceSuite(context: ImageWorkspaceTestContext) 
         "src",
         "http://localhost:8080/api/v1/sessions/22222222-2222-2222-2222-222222222222/image-generations/gen-44444444-4444-4444-4444-444444444444/images/asset-001/content",
       );
+      expect(
+        screen.getByRole("toolbar", { name: "Generated image actions for output.png" }),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Original 1024 x 1024")).toBeInTheDocument();
     });
 
     // Composer prompt should be cleared and ready for next turn
     expect(screen.getByLabelText("Image prompt")).toHaveValue("");
+  });
+
+  it("downloads the original generated image from the toolbar", async () => {
+    context.mockSuccessfulCreateImageGeneration();
+    const user = userEvent.setup();
+    const generatedImageUrl =
+      "http://localhost:8080/api/v1/sessions/22222222-2222-2222-2222-222222222222/image-generations/gen-44444444-4444-4444-4444-444444444444/images/asset-001/content";
+    const anchorClickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+
+    try {
+      context.mockedFetch.mockImplementation(async (input) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+
+        if (url === generatedImageUrl) {
+          return createImageContentResponse();
+        }
+
+        return new Response(JSON.stringify({ version: "test-version" }), {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json",
+          },
+        });
+      });
+
+      context.renderApp();
+      await context.waitForReady();
+
+      await user.click(screen.getByRole("button", { name: "New" }));
+      await user.click(screen.getByRole("menuitem", { name: "New Image" }));
+
+      await context.waitForImageReady();
+
+      await user.type(screen.getByLabelText("Image prompt"), "Download this image");
+      await user.click(screen.getByRole("button", { name: "Generate" }));
+
+      await waitFor(() => {
+        expect(context.mockedCreateImageGeneration).toHaveBeenCalledTimes(1);
+      });
+
+      act(() => {
+        context.requireImageStreamHandlers().onCompleted?.({
+          generationId: "gen-44444444-4444-4444-4444-444444444444",
+          sessionId: "22222222-2222-2222-2222-222222222222",
+          mode: "text_to_image",
+          status: "completed",
+          prompt: "Download this image",
+          resolution: { key: "1024x1024", width: 1024, height: 1024 },
+          outputImageCount: 1,
+          createdAt: "2026-03-31T10:01:00Z",
+          completedAt: "2026-03-31T10:01:05Z",
+          inputAssets: [],
+          outputAssets: [
+            {
+              assetId: "asset-001",
+              filename: "download-me.png",
+              mediaType: "image/png",
+              sizeBytes: 12345,
+              sha256: "abc123",
+              width: 1024,
+              height: 1024,
+              createdAt: "2026-03-31T10:01:05Z",
+              contentUrl:
+                "/api/v1/sessions/22222222-2222-2222-2222-222222222222/image-generations/gen-44444444-4444-4444-4444-444444444444/images/asset-001/content",
+            },
+          ],
+        });
+      });
+
+      await user.click(
+        screen.getByRole("button", { name: "Download original generated image download-me.png" }),
+      );
+
+      await waitFor(() => {
+        const downloadBlob = vi.mocked(URL.createObjectURL).mock.calls[0]?.[0];
+        expect(context.mockedFetch).toHaveBeenCalledWith(generatedImageUrl);
+        expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+        expect(downloadBlob).toBeDefined();
+        expect(downloadBlob).toMatchObject({
+          size: 9,
+          type: "image/png",
+        });
+        expect(anchorClickSpy).toHaveBeenCalledTimes(1);
+      });
+    } finally {
+      anchorClickSpy.mockRestore();
+    }
   });
 
   it("shows a second turn when a new generation is submitted after the first completes", async () => {

--- a/apps/frontend/src/styles/imagegen.css
+++ b/apps/frontend/src/styles/imagegen.css
@@ -82,16 +82,66 @@
 }
 
 .image-turn-outputs {
+  display: grid;
+  gap: 14px;
+  justify-items: start;
+}
+
+.image-turn-output-card {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+}
+
+.image-turn-output-frame {
+  width: min(100%, 32rem);
+  max-width: 100%;
   display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
+  align-items: center;
+  justify-content: center;
+  padding: 12px;
+  border-radius: 18px;
+  border: 1px solid rgba(56, 44, 30, 0.08);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.66), rgba(255, 247, 239, 0.94)),
+    var(--surface-strong);
 }
 
 .image-turn-output {
-  max-width: 100%;
+  max-width: min(100%, 32rem);
+  max-height: min(32rem, 58vh);
+  width: auto;
+  height: auto;
+  object-fit: contain;
   border-radius: 12px;
-  border: 1px solid rgba(56, 44, 30, 0.1);
   display: block;
+}
+
+.image-turn-output-toolbar {
+  width: min(100%, 32rem);
+  max-width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+  color: var(--muted);
+}
+
+.image-turn-output-meta {
+  font-size: 0.8rem;
+}
+
+.image-turn-output-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.image-turn-output-feedback {
+  font-size: 0.78rem;
+  color: var(--danger);
 }
 
 .image-turn-error {


### PR DESCRIPTION
## Summary
- render generated images in a bounded thumbnail frame instead of raw output size
- add an image toolbar with a download action that saves the original asset
- cover the toolbar and download flow in the image workspace tests

## Verification
- `npm test`
- `npm run build`