### PR TITLE
Enable image generation in frontend deploy build

### DIFF
--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -53,6 +53,7 @@ jobs:
             -f apps/frontend/Dockerfile \
             --build-arg VITE_API_BASE_URL="$FRONTEND_VITE_API_BASE_URL" \
             --build-arg VITE_APP_VERSION="$GITHUB_SHA" \
+            --build-arg VITE_IMAGE_GENERATION_ENABLED=true \
             -t "$FRONTEND_IMAGE" \
             apps/frontend
 


### PR DESCRIPTION
## Summary
- pass `VITE_IMAGE_GENERATION_ENABLED=true` to the frontend Docker build in the deploy workflow
- ensure the deployed frontend bundle includes the image-generation UI gate

## Verification
- inspected `apps/frontend/Dockerfile` and confirmed the flag is consumed as a build arg during `npm run build`
- inspected `.github/workflows/frontend-deploy.yml` and updated the build step to pass the flag
