### PR TITLE
Add FLUX image generation presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,17 +206,23 @@ Supported v1 image generation modes:
 
 Each generation always produces exactly 1 output image.
 
-Supported resolutions:
+Current app-exposed resolution presets:
 
 | Key | Width | Height |
 |---|---|---|
 | `1024x1024` | 1024 | 1024 |
+| `1536x864` | 1536 | 864 |
+| `864x1536` | 864 | 1536 |
+| `1280x1024` | 1280 | 1024 |
+| `1024x1280` | 1024 | 1280 |
 | `1152x896` | 1152 | 896 |
 | `896x1152` | 896 | 1152 |
 | `1344x768` | 1344 | 768 |
 | `768x1344` | 768 | 1344 |
 | `1536x1024` | 1536 | 1024 |
 | `1024x1536` | 1024 | 1536 |
+
+Azure AI Foundry `FLUX.2-pro` supports a broader range than this preset list. The official Microsoft Foundry and Black Forest Labs docs describe output resolution support as width/height values from `64x64` up to `4 MP`, with output dimensions always being multiples of `16`. For image edits, FLUX.2 matches the input image dimensions by default, rounded to multiples of `16`.
 
 Image generation endpoints:
 

--- a/apps/backend/internal/imagegen/service_test.go
+++ b/apps/backend/internal/imagegen/service_test.go
@@ -21,11 +21,30 @@ func TestSupportedResolutionsReturnsCatalogCopy(t *testing.T) {
 	t.Parallel()
 
 	resolutions := SupportedResolutions()
-	if len(resolutions) != 7 {
-		t.Fatalf("len(resolutions) = %d, want 7", len(resolutions))
+	if len(resolutions) != 11 {
+		t.Fatalf("len(resolutions) = %d, want 11", len(resolutions))
 	}
-	if resolutions[0].Key != "1024x1024" || resolutions[6].Key != "1024x1536" {
-		t.Fatalf("unexpected resolution catalog: %+v", resolutions)
+
+	keys := make([]string, 0, len(resolutions))
+	for _, resolution := range resolutions {
+		keys = append(keys, resolution.Key)
+	}
+
+	wantKeys := []string{
+		"1024x1024",
+		"1536x864",
+		"864x1536",
+		"1280x1024",
+		"1024x1280",
+		"1152x896",
+		"896x1152",
+		"1344x768",
+		"768x1344",
+		"1536x1024",
+		"1024x1536",
+	}
+	if !slices.Equal(keys, wantKeys) {
+		t.Fatalf("unexpected resolution catalog: %v", keys)
 	}
 
 	resolutions[0].Key = "changed"

--- a/apps/backend/internal/imagegen/types.go
+++ b/apps/backend/internal/imagegen/types.go
@@ -44,6 +44,10 @@ type Resolution struct {
 
 var supportedResolutionCatalog = []Resolution{
 	{Key: "1024x1024", Width: 1024, Height: 1024},
+	{Key: "1536x864", Width: 1536, Height: 864},
+	{Key: "864x1536", Width: 864, Height: 1536},
+	{Key: "1280x1024", Width: 1280, Height: 1024},
+	{Key: "1024x1280", Width: 1024, Height: 1280},
 	{Key: "1152x896", Width: 1152, Height: 896},
 	{Key: "896x1152", Width: 896, Height: 1152},
 	{Key: "1344x768", Width: 1344, Height: 768},


### PR DESCRIPTION
## Summary
- add four curated FLUX image generation presets
- keep `1024x1024` as the first/default preset
- update the backend resolution catalog test and README

## Verification
- `GOCACHE=/tmp/ulduar-go-build go test ./...`