### PR TITLE
Fix missing image-mode add references tooltip

### DIFF
--- a/apps/frontend/src/features/imagegen/components/ImageReusePicker.test.tsx
+++ b/apps/frontend/src/features/imagegen/components/ImageReusePicker.test.tsx
@@ -27,6 +27,28 @@ describe("ImageReusePicker", () => {
     );
   });
 
+  it("shows the add references tooltip and dismisses it after pressing the trigger", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ImageReusePicker
+        busy={false}
+        onOpenFilePicker={vi.fn()}
+        onReuseImage={vi.fn().mockResolvedValue(undefined)}
+        reusingImageIds={[]}
+        reusableImages={[]}
+      />,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Add reference images" });
+
+    await user.hover(trigger);
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Add references");
+
+    await user.click(trigger);
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
   it("opens the session picker only when reusable images exist", async () => {
     const user = userEvent.setup();
 

--- a/apps/frontend/src/features/imagegen/components/ImageReusePicker.tsx
+++ b/apps/frontend/src/features/imagegen/components/ImageReusePicker.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useId, useRef, useState, type KeyboardEvent } from "react";
 
+import { ActionTooltip } from "../../chat/components/ActionTooltip";
 import { IconAttachment, IconClose } from "../../chat/components/icons";
 import type { ReusableImageSource } from "../types";
 
@@ -115,26 +116,33 @@ export function ImageReusePicker({
 
   return (
     <div className="image-reuse-anchor">
-      <button
-        ref={triggerRef}
-        aria-controls={isOpen ? panelId : menuId}
-        aria-expanded={isMenuOpen || isOpen}
-        aria-haspopup={isOpen ? "dialog" : "menu"}
-        aria-label="Add reference images"
-        className="attachment-button icon-only-button"
-        disabled={busy}
-        type="button"
-        onClick={() => {
-          if (isOpen || isMenuOpen) {
-            closeAll();
-            return;
-          }
-
-          openMenu();
-        }}
+      <ActionTooltip
+        side="above"
+        dismissOnPress
+        openOnFocus={false}
+        content={<span className="action-tooltip-label">Add references</span>}
       >
-        <IconAttachment />
-      </button>
+        <button
+          ref={triggerRef}
+          aria-controls={isOpen ? panelId : menuId}
+          aria-expanded={isMenuOpen || isOpen}
+          aria-haspopup={isOpen ? "dialog" : "menu"}
+          aria-label="Add reference images"
+          className="attachment-button icon-only-button"
+          disabled={busy}
+          type="button"
+          onClick={() => {
+            if (isOpen || isMenuOpen) {
+              closeAll();
+              return;
+            }
+
+            openMenu();
+          }}
+        >
+          <IconAttachment />
+        </button>
+      </ActionTooltip>
 
       <div
         ref={menuRef}


### PR DESCRIPTION
## Summary
- wrap the image reference trigger in the shared action tooltip component
- show the `Add references` tooltip in image mode with the same dismiss-on-press behavior as chat mode
- add a regression test for the image reference trigger tooltip

## Verification
- `cd apps/frontend && npm test`
- `cd apps/frontend && npm run build`

Closes #100.