### PR TITLE
Enable web search for presentation planning

### DIFF
--- a/.env.compose.example
+++ b/.env.compose.example
@@ -34,7 +34,7 @@ AZURE_OPENAI_DEPLOYMENT=gpt-5-chat
 # Leave unset to use the default markdown-friendly prompt.
 # Set to an empty value to disable the default prompt intentionally.
 # AZURE_OPENAI_PRESENTATION_SYSTEM_PROMPT=
-# Disabled by default. Set to true only for local/dev/test rollout of Azure-native web_search.
+# Disabled by default. Set to true only for local/dev/test rollout of Azure-native web_search in chat and presentation planning.
 AZURE_OPENAI_ENABLE_WEB_SEARCH=false
 AZURE_OPENAI_REQUEST_TIMEOUT=90s
 AZURE_OPENAI_STREAM_TIMEOUT=10m

--- a/.env.example
+++ b/.env.example
@@ -32,7 +32,7 @@ AZURE_OPENAI_DEPLOYMENT=gpt-5-chat
 # Leave unset to use the default markdown-friendly prompt.
 # Set to an empty value to disable the default prompt intentionally.
 # AZURE_OPENAI_PRESENTATION_SYSTEM_PROMPT=
-# Disabled by default. Set to true only for local/dev/test rollout of Azure-native web_search.
+# Disabled by default. Set to true only for local/dev/test rollout of Azure-native web_search in chat and presentation planning.
 AZURE_OPENAI_ENABLE_WEB_SEARCH=false
 AZURE_OPENAI_REQUEST_TIMEOUT=90s
 AZURE_OPENAI_STREAM_TIMEOUT=10m

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Backend app startup validates these:
 - `AZURE_OPENAI_PRESENTATION_SYSTEM_PROMPT`
   Optional planner-specific system prompt prefix. The backend always appends the Ulduar v1 presentation-dialect JSON contract and strict "JSON only" instructions separately. If unset, this prefix defaults to the same markdown-friendly guidance as chat. Set it to an empty string only if you want to disable the prefix explicitly. Set it to a non-empty value to use that exact override.
 - `AZURE_OPENAI_ENABLE_WEB_SEARCH`
-  Optional boolean. Default `false`. When set to `true`, the backend includes Azure-native `web_search` in Responses API requests, persists final assistant URL citations, and may emit lightweight SSE `tool.status` events. Leave this disabled in production for now; enable it manually only in dev/test.
+  Optional boolean. Default `false`. When set to `true`, the backend includes Azure-native `web_search` in Responses API requests for chat and presentation planning. Chat persists final assistant URL citations and may emit lightweight SSE `tool.status` events. Leave this disabled in production for now; enable it manually only in dev/test.
 - `AZURE_OPENAI_REQUEST_TIMEOUT`
   Optional duration for non-stream Responses API calls. Default `90s`.
 - `AZURE_OPENAI_STREAM_TIMEOUT`
@@ -200,7 +200,7 @@ Frontend will be available at `http://localhost:3000`.
 
 ### Optional Azure web search in dev/test
 
-Web search stays disabled by default. To validate it locally, set `AZURE_OPENAI_ENABLE_WEB_SEARCH=true` before starting the backend, then ask a prompt where fresh web results are helpful.
+Web search stays disabled by default. To validate it locally, set `AZURE_OPENAI_ENABLE_WEB_SEARCH=true` before starting the backend, then try a chat prompt or presentation prompt where fresh web results are helpful.
 
 When Azure web search is available and the model chooses to use it:
 
@@ -211,6 +211,7 @@ When Azure web search is available and the model chooses to use it:
 Operational notes:
 
 - the model decides when to search; users do not need a special command
+- the same flag now applies to presentation-planner requests as well as chat requests
 - production rollout is still a separate manual config change
 - rollback is simply setting `AZURE_OPENAI_ENABLE_WEB_SEARCH=false` and restarting the backend
 
@@ -418,7 +419,7 @@ cd apps/backend
 GOCACHE=/tmp/ulduar-go-build go test ./...
 ```
 
-When `AZURE_OPENAI_ENABLE_WEB_SEARCH=true`, the backend still keeps the existing request and response shapes stable, but assistant message content may include optional citation metadata on text parts and the SSE stream may include `tool.status` events for Azure `web_search` progress. With the flag unset or `false`, backend behavior remains effectively unchanged.
+When `AZURE_OPENAI_ENABLE_WEB_SEARCH=true`, the backend still keeps the existing request and response shapes stable, but assistant message content may include optional citation metadata on text parts, the SSE stream may include `tool.status` events for Azure `web_search` progress, and presentation-planner requests may also use Azure-native `web_search`. With the flag unset or `false`, backend behavior remains effectively unchanged.
 
 Frontend:
 

--- a/apps/backend/cmd/server/main.go
+++ b/apps/backend/cmd/server/main.go
@@ -117,8 +117,9 @@ func main() {
 			RequestTimeout: cfg.Presentation.RequestTimeout,
 			StreamTimeout:  cfg.Presentation.StreamTimeout,
 		},
-		BlobStore:      blobClient,
-		ResponseClient: presentationClient,
+		BlobStore:       blobClient,
+		ResponseClient:  presentationClient,
+		EnableWebSearch: cfg.AzureOpenAIWebSearch,
 	})
 
 	server := &http.Server{

--- a/apps/backend/internal/presentationgen/service.go
+++ b/apps/backend/internal/presentationgen/service.go
@@ -118,14 +118,16 @@ type Service struct {
 	planner        PlannerConfig
 	blobs          BlobStore
 	responses      ResponseClient
+	webSearch      bool
 	generationRead generationReader
 	assetRead      assetReader
 }
 
 type ServiceOptions struct {
-	Planner        PlannerConfig
-	BlobStore      BlobStore
-	ResponseClient ResponseClient
+	Planner         PlannerConfig
+	BlobStore       BlobStore
+	ResponseClient  ResponseClient
+	EnableWebSearch bool
 }
 
 type ValidationError struct {
@@ -153,6 +155,7 @@ func NewService(db *pgxpool.Pool, options ...ServiceOptions) *Service {
 		planner:   resolvedOptions.Planner,
 		blobs:     resolvedOptions.BlobStore,
 		responses: resolvedOptions.ResponseClient,
+		webSearch: resolvedOptions.EnableWebSearch,
 	}
 	if db != nil {
 		service.beginWriteTxFn = func(ctx context.Context) (writeTx, error) {
@@ -417,7 +420,16 @@ func (s *Service) newCreateResponseRequest(ctx context.Context, generation repos
 	return azureopenai.CreateResponseRequest{
 		Input:        input,
 		Instructions: s.instructions(),
+		Tools:        s.responseTools(),
 	}, nil
+}
+
+func (s *Service) responseTools() []azureopenai.Tool {
+	if !s.webSearch {
+		return nil
+	}
+
+	return []azureopenai.Tool{{Type: "web_search"}}
 }
 
 func (s *Service) preparePlannerInput(ctx context.Context, generation repository.PresentationGeneration, assets []repository.PresentationGenerationAsset, repairMessage string) ([]azureopenai.InputMessage, error) {

--- a/apps/backend/internal/presentationgen/service_test.go
+++ b/apps/backend/internal/presentationgen/service_test.go
@@ -423,6 +423,9 @@ func TestExecuteGenerationBuildsAttachmentAwarePlannerRequestAndPersistsNormaliz
 	if got := client.requests[0].Instructions; !strings.Contains(got, "presentation-system-prompt") || !strings.Contains(got, "Return exactly one JSON object and nothing else.") {
 		t.Fatalf("request instructions = %q, want system prompt plus planner dialect instructions", got)
 	}
+	if len(client.requests[0].Tools) != 0 {
+		t.Fatalf("len(client.requests[0].Tools) = %d, want 0 by default", len(client.requests[0].Tools))
+	}
 
 	content := requestInput[0].Content
 	if len(content) != 3 {
@@ -472,6 +475,61 @@ func TestExecuteGenerationBuildsAttachmentAwarePlannerRequestAndPersistsNormaliz
 	}
 	if blobStore.uploadCalls[0].contentType != OutputMediaTypePPTX {
 		t.Fatalf("blobStore.uploadCalls[0].contentType = %q", blobStore.uploadCalls[0].contentType)
+	}
+}
+
+func TestExecuteGenerationIncludesWebSearchToolWhenEnabled(t *testing.T) {
+	t.Parallel()
+
+	reader := &stubGenerationReader{
+		generation: repository.PresentationGeneration{
+			ID:        "22222222-2222-2222-2222-222222222222",
+			SessionID: "11111111-1111-1111-1111-111111111111",
+			Prompt:    "Build a market overview deck",
+			Status:    string(StatusPending),
+		},
+		claimPendingResult: true,
+	}
+	client := &stubResponseClient{
+		responses: []azureopenai.Response{{
+			Model:      "gpt-5-presentation",
+			OutputText: `{"version":"v1","slides":[{"layout":"title","title":"Market overview"}]}`,
+		}},
+	}
+	tx := &stubWriteTx{
+		lockedGeneration: repository.PresentationGeneration{
+			ID:            "22222222-2222-2222-2222-222222222222",
+			SessionID:     "11111111-1111-1111-1111-111111111111",
+			ProviderName:  plannerProviderName,
+			ProviderModel: "presentation-deployment",
+			Status:        string(StatusRunning),
+		},
+	}
+
+	service := &Service{
+		planner: PlannerConfig{
+			Deployment: "presentation-deployment",
+		},
+		blobs:          &stubBlobStore{},
+		responses:      client,
+		webSearch:      true,
+		generationRead: reader,
+		assetRead:      stubAssetReader{},
+		beginWriteTxFn: func(context.Context) (writeTx, error) { return tx, nil },
+	}
+
+	if err := service.ExecuteGeneration(context.Background(), "22222222-2222-2222-2222-222222222222"); err != nil {
+		t.Fatalf("ExecuteGeneration() error = %v", err)
+	}
+
+	if len(client.requests) != 1 {
+		t.Fatalf("len(client.requests) = %d, want 1", len(client.requests))
+	}
+	if len(client.requests[0].Tools) != 1 {
+		t.Fatalf("len(client.requests[0].Tools) = %d, want 1", len(client.requests[0].Tools))
+	}
+	if client.requests[0].Tools[0].Type != "web_search" {
+		t.Fatalf("client.requests[0].Tools[0].Type = %q, want web_search", client.requests[0].Tools[0].Type)
 	}
 }
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -67,7 +67,7 @@ No rollout-notes document is required.
 - Loads all session state from Postgres and Blob Storage as needed
 - Calls Azure OpenAI Responses API for chat
 - Streams assistant output to the SPA via SSE
-- Can optionally attach Azure-native `web_search` behind backend configuration, disabled by default for manual rollout
+- Can optionally attach Azure-native `web_search` behind backend configuration for chat and presentation-planner requests, disabled by default for manual rollout
 - Supports a pluggable image generation provider; Azure AI Foundry FLUX is the initial configured adapter, enabled when both `AZURE_FOUNDRY_ENDPOINT` and `AZURE_FOUNDRY_API_KEY` are set
 - Supports a presentation planner/compiler workflow, enabled only when `AZURE_OPENAI_PRESENTATION_ENDPOINT` and related planner settings are configured
 
@@ -243,6 +243,7 @@ Environment variables should cover:
 - Azure model deployment name
 - System prompt or default assistant instruction
 - Optional Azure-native `web_search` enablement flag, disabled by default and intended for manual dev/test rollout first
+- The same flag applies to chat requests and presentation-planner requests
 - Web-search runs must preserve the existing session model, API shape, and anonymous chat flow while persisting only final citation metadata
 - `VITE_IMAGE_GENERATION_ENABLED` (frontend-only build flag): when unset or `false`, the image-generation UI is hidden entirely. Setting this to `true` exposes the image workspace but backend provider configuration is required separately for image generation to function.
 - `VITE_PRESENTATION_GENERATION_ENABLED` (frontend-only build flag): when unset or `false`, the presentation-generation UI is hidden entirely. Keep it disabled by default until manual validation passes. Setting this to `true` exposes the presentation workspace, but backend planner configuration is required separately for presentation generation to function.


### PR DESCRIPTION
## Summary
- honor `AZURE_OPENAI_ENABLE_WEB_SEARCH` in the presentation planner service
- attach Azure-native `web_search` tools to PPTX planning requests when the shared flag is enabled
- update backend docs, env examples, and tests to reflect that the flag now applies to chat and presentation planning

## Verification
- `cd apps/backend && GOCACHE=/tmp/ulduar-go-build go test ./internal/presentationgen ./cmd/server`
- `cd apps/backend && GOCACHE=/tmp/ulduar-go-build go test ./...`